### PR TITLE
Google sometimes returns html responses (WTF google?!); This is a guard from these

### DIFF
--- a/lib/HttpResponseProcessor.js
+++ b/lib/HttpResponseProcessor.js
@@ -16,7 +16,16 @@
                 responseData += chunk;
             });
             response.on("end", function () {
-                if (parseJson) responseData = JSON.parse(responseData);
+                if (parseJson) {
+                    //Google sometimes returns responses in HTML format (which is weird), so we need to guard from crashes
+                    try {
+                        responseData = JSON.parse(responseData);
+                    }
+                    catch (e) {
+                        callback(e, {});
+                        return;
+                    }
+                }
                 callback(null, responseData);
             });
         };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "googleplaces",
-    "version": "0.6.0",
+    "version": "0.6.1",
     "description": "Node.js library for the Google Places API",
     "keywords": [
         "google",


### PR DESCRIPTION
One day, I got this crashlog on my server:

undefined:1
<!DOCTYPE html>
^

```
at IncomingMessage.<anonymous> (/app/node_modules/googleplaces/lib/HttpResponseProcessor.js:19:52)
```

SyntaxError: Unexpected token <
    at Object.parse (native)
    at emitNone (events.js:85:20)
    at IncomingMessage.emit (events.js:179:7)
    at endReadableNT (_stream_readable.js:913:12)
    at _combinedTickCallback (internal/process/next_tick.js:74:11)
npm ERR! Linux 3.13.0-79-generic
npm ERR! argv "/app/.heroku/node/bin/node" "/app/.heroku/node/bin/npm" "start"
npm ERR! npm  v3.8.3
npm ERR! node v5.10.1
    at process._tickDomainCallback (internal/process/next_tick.js:122:9)

npm ERR! server@0.0.0 start: `node ./bin/www`
npm ERR! code ELIFECYCLE
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the server@0.0.0 start script 'node ./bin/www'.
npm ERR! If you do, this is most likely a problem with the server package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR! Make sure you have the latest version of node.js and npm installed.
npm ERR! You can get information on how to open an issue for this project with:
npm ERR!     npm bugs server
npm ERR!     npm owner ls server
npm ERR! There is likely additional logging output above.

npm ERR!     node ./bin/www
npm ERR! Or if that isn't available, you can get their info via:
npm ERR! Please include the following file with any support request:
npm ERR!     /app/npm-debug.log

So Google does return html from time to time.
This is a big WTF in itself, but we have to catch these errors anyway! 

This commit just adds a try-catch around JSON.parse;
