### PR TITLE
add pagination & cache override token

### DIFF
--- a/lib/PlaceSearch.js
+++ b/lib/PlaceSearch.js
@@ -13,6 +13,8 @@
             validate.outputFormat(outputFormat);
             parameters.key = apiKey;
             parameters.location = parameters.location || "-33.8670522,151.1957362";
+            parameters.pagetoken = parameters.pagetoken || '';
+            parameters._ = (new Date()).getTime().toString(36);
             if (typeof parameters.location === "object") parameters.location = parameters.location.toString();
             if (!parameters.rankby) parameters.radius = parameters.radius || 500;
             parameters.sensor = parameters.sensor || false;

--- a/lib/RadarSearch.js
+++ b/lib/RadarSearch.js
@@ -13,6 +13,8 @@
             validate.outputFormat(outputFormat);
             parameters.key = apiKey;
             parameters.location = parameters.location || "-33.8670522,151.1957362";
+            parameters.pagetoken = parameters.pagetoken || '';
+            parameters._ = (new Date()).getTime().toString(36);
             if (typeof parameters.location === "object") parameters.location = parameters.location.toString();
             parameters.radius = parameters.radius || 500;
             parameters.sensor = parameters.sensor || false;

--- a/lib/TextSearch.js
+++ b/lib/TextSearch.js
@@ -14,6 +14,8 @@
             parameters.key = apiKey;
             parameters.query = parameters.query || "restaurant";
             parameters.sensor = parameters.sensor || false;
+            parameters.pagetoken = parameters.pagetoken || '';
+            parameters._ = (new Date()).getTime().toString(36);
             if (typeof parameters.location === "object") parameters.location = parameters.location.toString();
             var options = {
                 hostname: "maps.googleapis.com",


### PR DESCRIPTION
I needed more than 20 results per search and the library doesn't provide a way to paginate.
I added the pagetoken parameter and a cache override token, to prevent potential cache issue described here (answer by dmmd):
https://stackoverflow.com/questions/21265756/paging-on-google-places-api-returns-status-invalid-request

Furthermore, the API has this weird behavior when it comes to pagination that the token does not become immediately available and you have to "sleep" before making the next page request otherwise it returns INVALID_REQUEST error. Not sure if this should be part of the library?

More information:
https://developers.google.com/places/web-service/search